### PR TITLE
fix: Landing page build

### DIFF
--- a/terrakube_landing/package.json
+++ b/terrakube_landing/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build && next-on-pages",
+    "dev": "next dev --turbopack",
+    "build": "next build",
+    "build-cloudfare": "npx @cloudflare/next-on-pages@1",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Fix compilation issue with new command `npm run build-cloudfare`

```shelll
node ➜ /workspaces/landing/terrakube_landing (fix/build) $ npm run build-cloudfare

> terrakube_landing@0.1.0 build-cloudfare
> npx @cloudflare/next-on-pages@1

⚡️ @cloudflare/next-on-pages CLI v.1.13.12
⚡️ Detected Package Manager: npm (10.9.2)
⚡️ Preparing project...
⚡️ Project is ready
⚡️ Building project...
▲  Vercel CLI 44.4.1
▲  WARN! Build not running on Vercel. System environment variables will not be available.
▲  WARNING: You should not upload the `.next` directory.
▲  Installing dependencies...
▲  up to date in 603ms
▲  174 packages are looking for funding
▲  run `npm fund` for details
▲  Detected Next.js version: 15.4.1
▲  Running "npm run build"
▲  > terrakube_landing@0.1.0 build
▲  > next build
▲  ▲ Next.js 15.4.1
▲  
▲  Creating an optimized production build ...
▲  ✓ Compiled successfully in 4.0s
▲  Linting and checking validity of types ...
▲  Collecting page data ...
▲  Generating static pages (0/4) ...
▲  Generating static pages (1/4)
▲  Generating static pages (2/4) 
▲    Generating static pages (3/4) 
▲  ✓ Generating static pages (4/4)
▲  Finalizing page optimization ...
▲  Collecting build traces ...
▲  
▲  Route (app)                                 Size  First Load JS
▲  ┌ ○ /                                      162 B         105 kB
▲  └ ○ /_not-found                            989 B         101 kB
▲  + First Load JS shared by all            99.6 kB
▲  ├ chunks/4bd1b696-cf72ae8a39fa05aa.js  54.1 kB
▲  ├ chunks/964-eda38e26c0391a47.js       43.5 kB
▲  └ other shared chunks (total)           1.9 kB
▲  ○  (Static)  prerendered as static content
▲  Traced Next.js server files in: 137.039ms
▲  Created all serverless functions in: 48.071ms
▲  Collected static files (public/, static/, .next/static): 2.542ms
▲  Build Completed in .vercel/output [15s]
⚡️ Completed `npx vercel build`.

⚡️ Build Summary (@cloudflare/next-on-pages v1.13.12)
⚡️ 
⚡️ Prerendered Routes (2)
⚡️   ┌ /
⚡️   └ /index.rsc
⚡️ 
⚡️ Other Static Assets (50)
⚡️   ┌ /_app.rsc.json
⚡️   ├ /_document.rsc.json
⚡️   ├ /_error.rsc.json
⚡️   ├ /404.html
⚡️   └ ... 46 more

⚡️ Build log saved to '.vercel/output/static/_worker.js/nop-build-log.json'
⚡️ Generated '.vercel/output/static/_worker.js/index.js'.
⚡️ Build completed in 0.06s
```

Files generated correctly 

<img width="287" height="821" alt="image" src="https://github.com/user-attachments/assets/8d451703-807e-48e4-ab63-2810dd1c42a7" />


Fix #1 